### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rayyildiz/chatbox/security/code-scanning/1](https://github.com/rayyildiz/chatbox/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly limit the permissions of the `GITHUB_TOKEN`. Based on the workflow's steps, it appears that only read access to the repository contents is required. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
